### PR TITLE
Fix detector view UI exception

### DIFF
--- a/AngularApp/src/app/diagnostic-data/components/detector-view/detector-view.component.ts
+++ b/AngularApp/src/app/diagnostic-data/components/detector-view/detector-view.component.ts
@@ -57,17 +57,20 @@ export class DetectorViewComponent implements OnInit {
         this.ratingEventProperties = {
           "DetectorId": data.metadata.id
         }
-
-        let separators = [' ', ',', ';', ':'];
-        let authors = data.metadata.author.split(new RegExp(separators.join('|'), 'g'));
-        let authorsArray: string[] = [];
-        authors.forEach(author => {
-          if (author && author.length > 0)
-          {
-            authorsArray.push(`${author}@microsoft.com`);
-          }
-        });
-        this.authorEmails  = authorsArray.join(";");
+        
+        if (data.metadata && data.metadata.author)
+        {
+          let separators = [' ', ',', ';', ':'];
+          let authors = data.metadata.author.split(new RegExp(separators.join('|'), 'g'));
+          let authorsArray: string[] = [];
+          authors.forEach(author => {
+            if (author && author.length > 0)
+            {
+              authorsArray.push(`${author}@microsoft.com`);
+            }
+          });
+          this.authorEmails  = authorsArray.join(";");
+        }
       }
     });
 


### PR DESCRIPTION
Seems like once there's an exception on UI, ngOnInit() won't be called for the second time..